### PR TITLE
OUT-1027 Hover state over attachments button should be a rectangle, not a circle

### DIFF
--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -290,7 +290,6 @@ export const Editor = ({
             maxWidth: '600px',
             display: 'flex',
             flexDirection: 'column',
-            gap: '12px',
           }
         }
       >
@@ -328,8 +327,13 @@ export const Editor = ({
           >
             {editor.isEditable && (
               <IconButton
-                style={{
+                sx={{
                   display: editor.isEditable ? 'flex' : 'none',
+                  transition: 'background-color 0.3s, border 0.3s',
+                  '&:hover': {
+                    borderRadius: '4px',
+                    background: '#F8F9FB',
+                  },
                 }}
                 onClick={() =>
                   uploadCommand({ editor, range: editor.state.selection })

--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -290,6 +290,7 @@ export const Editor = ({
             maxWidth: '600px',
             display: 'flex',
             flexDirection: 'column',
+            gap: '12px',
           }
         }
       >

--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -329,7 +329,7 @@ export const Editor = ({
               <IconButton
                 sx={{
                   display: editor.isEditable ? 'flex' : 'none',
-                  transition: 'background-color 0.3s, border 0.3s',
+
                   '&:hover': {
                     borderRadius: '4px',
                     background: '#F8F9FB',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwrite",
   "private": false,
-  "version": "1.1.78",
+  "version": "1.1.79",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,7 +30,6 @@ const App = () => {
           console.log(newContent)
         }}
         editorClass=''
-        addAttachmentButton
       />
     </div>
   )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -30,6 +30,7 @@ const App = () => {
           console.log(newContent)
         }}
         editorClass=''
+        addAttachmentButton
       />
     </div>
   )


### PR DESCRIPTION
### Changes 

- [x] hover state of attachment button changed from circular to rectangular with right color.

### Testing 

![image](https://github.com/user-attachments/assets/72315711-174d-43c8-b1f6-fdb96160faf7)
