### PR TITLE
fix(OUT-1112) : added naturalWidth check before updating dimensions.

### DIFF
--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -251,7 +251,7 @@ export const Editor = ({
       }
 
       if (readonly) {
-        editor.setEditable(readonly)
+        editor.setEditable(!readonly)
       }
     }
   }, [editor, readonly])

--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -251,7 +251,7 @@ export const Editor = ({
       }
 
       if (readonly) {
-        editor.setEditable(false)
+        editor.setEditable(readonly)
       }
     }
   }, [editor, readonly])

--- a/lib/components/tiptap/image/ImageResizeComponent.tsx
+++ b/lib/components/tiptap/image/ImageResizeComponent.tsx
@@ -39,7 +39,7 @@ export const ImageResizeComponent = (props: any) => {
       if (typeof props.node.attrs.height !== 'number') {
         props.updateAttributes({ height: naturalHeight })
       }
-      if (naturalWidth < 40) {
+      if (naturalWidth && naturalWidth < 40) {
         props.updateAttributes({
           width: 40,
           height: 40 / (naturalWidth / naturalHeight),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwrite",
   "private": false,
-  "version": "1.1.79",
+  "version": "1.1.80",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
- When natural width of the image is 0 or undefined, the image would still set width as 40 and height as 40 /(0/40) which is NaN. 
