### PR TITLE
OUT-1383 |  added a mechanism to append end buttons in the editor.

### DIFF
--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -39,7 +39,7 @@ import { NotionLikeProps } from '../main'
 import { UploadImage } from './tiptap/image/imageUpload'
 import { EditorState } from '@tiptap/pm/state'
 import { UploadAttachment } from './tiptap/attachments/attachmentUpload'
-import { Box, IconButton } from '@mui/material'
+import { Box, IconButton, Stack } from '@mui/material'
 import { AttachmentIcon } from '../icons'
 import { uploadCommand } from '../utils/uploadCommand'
 // import suggestion from "../components/tiptap/mention/suggestion.ts";
@@ -64,6 +64,7 @@ export const Editor = ({
   addAttachmentButton,
   maxUploadLimit,
   parentContainerStyle,
+  endButtons,
 }: NotionLikeProps) => {
   const initialEditorContent = placeholder ?? 'Type "/" for commands'
 
@@ -315,31 +316,34 @@ export const Editor = ({
           onFocus={() => editor.commands.focus()}
           tabIndex={0}
         />
-        {uploadFn && addAttachmentButton && (
-          <Box
-            style={{
-              alignSelf: 'flex-end',
-            }}
-          >
-            {editor.isEditable && (
-              <IconButton
-                sx={{
-                  display: editor.isEditable ? 'flex' : 'none',
+        <Stack
+          direction='row'
+          columnGap={'12px'}
+          sx={{ alignSelf: 'self-end' }}
+        >
+          {uploadFn && addAttachmentButton && (
+            <Box>
+              {editor.isEditable && (
+                <IconButton
+                  sx={{
+                    display: editor.isEditable ? 'flex' : 'none',
 
-                  '&:hover': {
-                    borderRadius: '4px',
-                    background: '#F8F9FB',
-                  },
-                }}
-                onClick={() =>
-                  uploadCommand({ editor, range: editor.state.selection })
-                }
-              >
-                <AttachmentIcon />
-              </IconButton>
-            )}
-          </Box>
-        )}
+                    '&:hover': {
+                      borderRadius: '4px',
+                      background: '#F8F9FB',
+                    },
+                  }}
+                  onClick={() =>
+                    uploadCommand({ editor, range: editor.state.selection })
+                  }
+                >
+                  <AttachmentIcon />
+                </IconButton>
+              )}
+            </Box>
+          )}
+          {endButtons}
+        </Stack>
       </div>
     </>
   )

--- a/lib/main.tsx
+++ b/lib/main.tsx
@@ -37,6 +37,7 @@ export interface NotionLikeProps {
   addAttachmentButton?: boolean
   maxUploadLimit?: number
   parentContainerStyle?: React.CSSProperties
+  endButtons?: React.ReactNode
 }
 
 export const Tapwrite = ({
@@ -57,7 +58,8 @@ export const Tapwrite = ({
   attachmentLayout,
   addAttachmentButton,
   maxUploadLimit,
-  parentContainerStyle
+  parentContainerStyle,
+  endButtons,
 }: NotionLikeProps) => {
   return (
     <AppContextProvider>
@@ -80,6 +82,7 @@ export const Tapwrite = ({
         addAttachmentButton={addAttachmentButton}
         maxUploadLimit={maxUploadLimit}
         parentContainerStyle={parentContainerStyle}
+        endButtons={endButtons}
       />
     </AppContextProvider>
   )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwrite",
   "private": false,
-  "version": "1.1.82",
+  "version": "1.1.83",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
- the endbuttons could be any reactNode, specially used for buttons like submit, save, cancel....



### Testing 

![image](https://github.com/user-attachments/assets/0e0f5d7d-2f62-4e3e-83a5-5bb1418a11bb)
