### PR TITLE
OUT-2179 | Handle edge case where props.editor is not defined

### DIFF
--- a/lib/components/tiptap/floatingMenu/floatingMenuSuggestion.tsx
+++ b/lib/components/tiptap/floatingMenu/floatingMenuSuggestion.tsx
@@ -205,11 +205,13 @@ export const floatingMenuSuggestion = (
         if (props.event.key === 'Escape') {
           popup[0].hide()
 
-          props.editor.storage.floatingCommand = {
-            ...props.editor.storage.floatingCommand,
-            isActive: false,
+          if (props.editor) {
+            props.editor.storage.floatingCommand = {
+              ...props.editor.storage.floatingCommand,
+              isActive: false,
+            }
+            props.editor.emit('floatingCommandUpdate')
           }
-          props.editor.emit('floatingCommandUpdate')
 
           return true
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwrite",
   "private": false,
-  "version": "1.1.91",
+  "version": "1.1.92",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
Ref: https://copilot-platforms.sentry.io/issues/6808457356/events/843dea8fc12c4eff8b6db1108b0f2886/

Changes:
- [x] Add check to see if `props.editor` is defined before calling for the floatingCommand config in editor's storage