### PR TITLE
feat(OUT-3440): add dynamic fields and handlebars support

### DIFF
--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -1,6 +1,6 @@
 import { EditorContent, useEditor } from '@tiptap/react'
 import * as React from 'react'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import Bold from '@tiptap/extension-bold'
 import BulletList from '@tiptap/extension-bullet-list'
@@ -263,14 +263,18 @@ export const Editor = ({
     onFocus: () => onFocus && onFocus(),
   })
 
+  // Use ref for editor to avoid unnecessary dispatches when editor instance changes
+  const tiptapEditorRef = useRef(editor)
+  tiptapEditorRef.current = editor
+
   // Sync dynamic field display when config props change
   useEffect(() => {
-    if (!editor || !autofillEnabled) return
-    editor.storage.autofillField.resolvedValues = dynamicFieldConfig?.resolvedValues ?? {}
-    editor.storage.autofillField.showDynamicFieldValue = dynamicFieldConfig?.showResolved ?? false
+    if (!tiptapEditorRef.current || !autofillEnabled) return
+    tiptapEditorRef.current.storage.autofillField.resolvedValues = dynamicFieldConfig?.resolvedValues ?? {}
+    tiptapEditorRef.current.storage.autofillField.showDynamicFieldValue = dynamicFieldConfig?.showResolved ?? false
     // Force all node views to re-render
-    editor.view.dispatch(editor.state.tr)
-  }, [dynamicFieldConfig?.resolvedValues, dynamicFieldConfig?.showResolved, editor, autofillEnabled])
+    tiptapEditorRef.current.view.dispatch(tiptapEditorRef.current.state.tr)
+  }, [dynamicFieldConfig?.resolvedValues, dynamicFieldConfig?.showResolved, autofillEnabled])
 
   useEffect(() => {
     if (editor && content !== editor.getHTML()) {

--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -67,6 +67,7 @@ export const Editor = ({
   parentContainerStyle,
   endButtons,
   editorRef,
+  dynamicFieldConfig,
 }: NotionLikeProps) => {
   const initialEditorContent = placeholder ?? 'Type "/" for commands'
 
@@ -79,6 +80,9 @@ export const Editor = ({
 
   const isTextInputClassName =
     'p-1.5 px-2.5  focus-within:border-black border-gray-300 bg-white border focus:border-black rounded-100  text-sm resize-y overflow-auto'
+
+  const autofillEnabled = !!(dynamicFieldConfig?.fields?.length)
+
   const editor = useEditor({
     editorProps: {
       attributes: {
@@ -86,7 +90,17 @@ export const Editor = ({
       },
     },
     extensions: [
-      AutofillExtension,
+      ...(autofillEnabled
+        ? [
+            AutofillExtension.configure({
+              dynamicFields: dynamicFieldConfig!.fields,
+              resolvedValues: dynamicFieldConfig!.resolvedValues ?? {},
+              showDynamicFieldValue: dynamicFieldConfig!.showResolved ?? false,
+              CustomDropdown: dynamicFieldConfig!.dropdownComponent,
+              TemplateComponent: dynamicFieldConfig!.templateComponent,
+            }),
+          ]
+        : []),
       IframeExtension.configure({
         allowFullscreen: true,
       }),
@@ -249,12 +263,14 @@ export const Editor = ({
     onFocus: () => onFocus && onFocus(),
   })
 
-  // useEffect(() => {
-  //   if (editor) {
-  //     editor.storage.MentionStorage.suggestions = suggestions;
-  //   }
-  // }, [suggestions, editor]);
-  // mention turned off for now
+  // Sync dynamic field display when config props change
+  useEffect(() => {
+    if (!editor || !autofillEnabled) return
+    editor.storage.autofillField.resolvedValues = dynamicFieldConfig?.resolvedValues ?? {}
+    editor.storage.autofillField.showDynamicFieldValue = dynamicFieldConfig?.showResolved ?? false
+    // Force all node views to re-render
+    editor.view.dispatch(editor.state.tr)
+  }, [dynamicFieldConfig?.resolvedValues, dynamicFieldConfig?.showResolved, editor, autofillEnabled])
 
   useEffect(() => {
     if (editor && content !== editor.getHTML()) {

--- a/lib/components/tiptap/autofieldSelector/AutofillComponent.tsx
+++ b/lib/components/tiptap/autofieldSelector/AutofillComponent.tsx
@@ -1,10 +1,61 @@
-import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
-import React from 'react'
+import { type NodeViewProps, NodeViewWrapper } from '@tiptap/react'
+import React, { useEffect, useReducer } from 'react'
+import type { DynamicField, HandlebarTemplateComponent } from './autofill-field.types'
 
-export const AutofillComponent = () => {
+export const AutofillComponent = ({ node, editor, extension }: NodeViewProps) => {
+  const value = node.attrs.value as string
+
+  // Force re-render on every transaction so we always read fresh storage values
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0)
+
+  useEffect(() => {
+    editor.on('transaction', forceUpdate)
+    return () => {
+      editor.off('transaction', forceUpdate)
+    }
+  }, [editor])
+
+  const showResolved: boolean = extension.storage.showDynamicFieldValue ?? false
+  const resolvedValues: Record<string, string> = extension.storage.resolvedValues ?? {}
+  const TemplateComponent: HandlebarTemplateComponent | undefined = extension.options.TemplateComponent
+
+  const dynamicFields: DynamicField[] = extension.options.dynamicFields ?? []
+  const fieldDef = dynamicFields.find((f) => f.value === value)
+  const label = fieldDef?.label ?? value
+
+  // Resolved mode: show plain resolved text
+  if (showResolved) {
+    return (
+      <NodeViewWrapper as="span" className="inline-flex align-baseline">
+        <span>{resolvedValues[value] ?? value}</span>
+      </NodeViewWrapper>
+    )
+  }
+
+   // Custom template component
+  if (TemplateComponent) {
+    return (
+      <NodeViewWrapper as="span" className="mx-0.5 inline-flex align-baseline">
+        <TemplateComponent
+          value={value}
+          label={label}
+          showResolved={showResolved}
+          resolvedValue={resolvedValues[value]}
+        />
+      </NodeViewWrapper>
+    )
+  }
+
+  // Default template pill — matches client-home-v3 style with {{ }}
   return (
-    <NodeViewWrapper className='pill-extension' as='span'>
-      <NodeViewContent as='span' />
+    <NodeViewWrapper as="span" className="inline-flex align-baseline">
+      <span
+        title={value}
+        style={{ fontSize: 'inherit', lineHeight: 1.25 }}
+        className="relative inline-flex w-fit max-w-full items-center overflow-clip rounded border border-gray-300 bg-white px-1 font-normal text-gray-500"
+      >
+        <span className="line-clamp-1 text-ellipsis break-all">{value}</span>
+      </span>
     </NodeViewWrapper>
   )
 }

--- a/lib/components/tiptap/autofieldSelector/AutofillMenu.tsx
+++ b/lib/components/tiptap/autofieldSelector/AutofillMenu.tsx
@@ -1,99 +1,93 @@
 import * as React from 'react'
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
+import type { DynamicField, DynamicFieldDropdownComponent } from './autofill-field.types'
 
-const AutofillContainerBtn = ({
-  handleClick,
-  label,
-  focus,
+type AutofillMenuProps = {
+  items: DynamicField[]
+  command: (item: DynamicField) => void
+  CustomDropdown?: DynamicFieldDropdownComponent
+}
+
+const DefaultDropdownItem = ({
+  field,
+  focused,
+  onClick,
 }: {
-  handleClick: () => void
-  label: string
-  focus: boolean
+  field: DynamicField
+  focused: boolean
+  onClick: () => void
 }) => {
   return (
     <button
-      className={`flex flex-row gap-x-2.5 items-center py-1.5 px-3 cursor-pointer outline-none ${focus && 'bg-new-white-2'
-        } display-block`}
-      onClick={() => {
-        handleClick()
-      }}
+      className={`flex flex-row gap-x-2.5 items-center py-1.5 px-3 cursor-pointer outline-none w-full text-left ${
+        focused ? 'bg-new-white-2' : ''
+      }`}
+      onClick={onClick}
     >
-      <div>
-        <p className='text-sm'>{label}</p>
-      </div>
+      <p className="text-sm">{field.label}</p>
     </button>
   )
 }
 
-export const AutofillMenu = forwardRef((props: any, ref: any) => {
+export const AutofillMenu = forwardRef<
+  { onKeyDown: (args: { event: KeyboardEvent }) => boolean },
+  AutofillMenuProps
+>((props, ref) => {
+  const { items, command, CustomDropdown } = props
   const [selectedIndex, setSelectedIndex] = useState(0)
 
-  const selectItem = (index: any) => {
-    const item = props.items[index]
-
+  const selectItem = (index: number) => {
+    const item = items[index]
     if (item) {
-      props.command({ id: item })
+      command(item)
     }
   }
 
-  const upHandler = () => {
-    setSelectedIndex(
-      (selectedIndex + props.items.length - 1) % props.items.length,
-    )
-  }
-
-  const downHandler = () => {
-    setSelectedIndex((selectedIndex + 1) % props.items.length)
-  }
-
-  const enterHandler = () => {
-    selectItem(selectedIndex)
-  }
-
-  useEffect(() => setSelectedIndex(0), [props.items])
+  useEffect(() => setSelectedIndex(0), [items])
 
   useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }: any) => {
+    onKeyDown: ({ event }: { event: KeyboardEvent }) => {
       if (event.key === 'ArrowUp') {
-        upHandler()
+        setSelectedIndex((i) => (i - 1 + items.length) % items.length)
         return true
       }
-
       if (event.key === 'ArrowDown') {
-        downHandler()
+        setSelectedIndex((i) => (i + 1) % items.length)
         return true
       }
-
       if (event.key === 'Enter') {
-        enterHandler()
+        selectItem(selectedIndex)
         return true
       }
-
       return false
     },
   }))
 
-  const { items } = props
+  if (CustomDropdown) {
+    return (
+      <CustomDropdown
+        items={items}
+        onSelect={(field) => command(field)}
+        selectedIndex={selectedIndex}
+      />
+    )
+  }
 
   return (
-    <div className='flex flex-col gap-0.5 bg-white py-2 border border-new-card-border rounded shadow-vairant-1 w-fit overflow-hidden relative'>
-      {items && items?.length ? (
-        items.map((item: any, index: any) => (
-          <AutofillContainerBtn
-            key={index}
-            handleClick={() => {
-              selectItem(index)
-            }}
-            label={item}
-            focus={index === selectedIndex}
+    <div className="flex flex-col gap-0.5 bg-white py-2 border border-new-card-border rounded shadow-vairant-1 w-fit overflow-hidden relative max-h-72 overflow-y-auto min-w-[192px]">
+      {items.length > 0 ? (
+        items.map((field, index) => (
+          <DefaultDropdownItem
+            key={field.value}
+            field={field}
+            focused={index === selectedIndex}
+            onClick={() => selectItem(index)}
           />
         ))
       ) : (
-        <AutofillContainerBtn
-          label={'No Options'}
-          handleClick={() => { }}
-          focus={false}
-        />
+        <div className="py-1.5 px-3">
+          <p className="text-sm text-gray-400">No fields found</p>
+        </div>
       )}
     </div>
   )

--- a/lib/components/tiptap/autofieldSelector/autofill-field.types.ts
+++ b/lib/components/tiptap/autofieldSelector/autofill-field.types.ts
@@ -1,0 +1,33 @@
+import { ComponentType } from 'react'
+
+export type DynamicField = {
+  value: string
+  label: string
+}
+
+export type ResolvedValues = Record<string, string>
+
+export type DynamicFieldDropdownProps = {
+  items: DynamicField[]
+  onSelect: (field: DynamicField) => void
+  selectedIndex: number
+}
+
+export type DynamicFieldDropdownComponent = ComponentType<DynamicFieldDropdownProps>
+
+export type HandlebarTemplateProps = {
+  value: string
+  label: string
+  showResolved: boolean
+  resolvedValue?: string
+}
+
+export type HandlebarTemplateComponent = ComponentType<HandlebarTemplateProps>
+
+export type DynamicFieldConfig = {
+  fields: DynamicField[]
+  resolvedValues?: ResolvedValues
+  showResolved?: boolean
+  dropdownComponent?: DynamicFieldDropdownComponent
+  templateComponent?: HandlebarTemplateComponent
+}

--- a/lib/components/tiptap/autofieldSelector/autofillMenuSuggestion.ts
+++ b/lib/components/tiptap/autofieldSelector/autofillMenuSuggestion.ts
@@ -1,38 +1,29 @@
 import { ReactRenderer } from '@tiptap/react'
-import tippy from 'tippy.js'
+import tippy, { type Instance, type Props as TippyProps } from 'tippy.js'
 import { AutofillMenu } from './AutofillMenu'
+import type { DynamicField, DynamicFieldDropdownComponent } from './autofill-field.types'
 
-
-export const autofillMenuSuggestion = {
-  items: async ({ query }: any) => {
-    return [
-      'not yet'
-    ]
-
-      .filter((item: any) =>
-        item.toLowerCase().replaceAll('{{', '').startsWith(query.toLowerCase()),
-      )
+export const autofillMenuSuggestion = (
+  dynamicFields: DynamicField[],
+  CustomDropdown?: DynamicFieldDropdownComponent,
+) => ({
+  items: ({ query }: { query: string }): DynamicField[] => {
+    const normalized = query.toLowerCase()
+    return dynamicFields
+      .filter((item) => item.label.toLowerCase().includes(normalized))
       .slice(0, 10)
   },
 
   char: '{{',
 
   render: () => {
-    let component: any
-    let popup: any
+    let component: ReactRenderer<{ onKeyDown: (args: { event: KeyboardEvent }) => boolean }> | null = null
+    let popup: Instance<TippyProps>[] | null = null
 
     return {
-      addAttributes() {
-        return {
-          customFields: {
-            default: [],
-          },
-        }
-      },
-
       onStart: (props: any) => {
         component = new ReactRenderer(AutofillMenu, {
-          props,
+          props: { ...props, CustomDropdown },
           editor: props.editor,
         })
 
@@ -52,31 +43,32 @@ export const autofillMenuSuggestion = {
       },
 
       onUpdate(props: any) {
-        component.updateProps(props)
+        component?.updateProps({ ...props, CustomDropdown })
 
         if (!props.clientRect) {
           return
         }
 
-        popup[0].setProps({
+        popup?.[0]?.setProps({
           getReferenceClientRect: props.clientRect,
         })
       },
 
       onKeyDown(props: any) {
         if (props.event.key === 'Escape') {
-          popup[0].hide()
-
+          popup?.[0]?.hide()
           return true
         }
 
-        return component?.ref?.onKeyDown(props)
+        return component?.ref?.onKeyDown(props) ?? false
       },
 
       onExit() {
-        popup[0].destroy()
-        component.destroy()
+        popup?.[0]?.destroy()
+        popup = null
+        component?.destroy()
+        component = null
       },
     }
   },
-}
+})

--- a/lib/components/tiptap/autofieldSelector/ext_autofill.ts
+++ b/lib/components/tiptap/autofieldSelector/ext_autofill.ts
@@ -1,29 +1,129 @@
 import { mergeAttributes, Node } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
 import { ReactNodeViewRenderer } from '@tiptap/react'
+import { Suggestion } from '@tiptap/suggestion'
 import { AutofillComponent } from './AutofillComponent'
+import { autofillMenuSuggestion } from './autofillMenuSuggestion'
+import type {
+  DynamicField,
+  DynamicFieldDropdownComponent,
+  HandlebarTemplateComponent,
+  ResolvedValues,
+} from './autofill-field.types'
 
-export const AutofillExtension = Node.create({
-  name: 'autofillComponent',
+const autofillSuggestionKey = new PluginKey('autofillSuggestion')
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    autofillField: {
+      insertAutofillField: (attrs: { value: string }) => ReturnType
+    }
+  }
+}
+
+export interface AutofillExtensionOptions {
+  dynamicFields: DynamicField[]
+  resolvedValues: ResolvedValues
+  showDynamicFieldValue: boolean
+  CustomDropdown?: DynamicFieldDropdownComponent
+  TemplateComponent?: HandlebarTemplateComponent
+}
+
+export const AutofillExtension = Node.create<AutofillExtensionOptions>({
+  name: 'autofillField',
   group: 'inline',
-  content: 'inline*',
   inline: true,
-  selectable: false,
   atom: true,
-  parseHTML() {
-    return [
-      {
-        tag: 'autofill',
-      },
-    ]
+  selectable: true,
+
+  addOptions() {
+    return {
+      dynamicFields: [],
+      resolvedValues: {},
+      showDynamicFieldValue: false,
+      CustomDropdown: undefined,
+      TemplateComponent: undefined,
+    }
   },
 
-  whitespace: 'normal',
+  addStorage() {
+    return {
+      resolvedValues: {} as ResolvedValues,
+      showDynamicFieldValue: false,
+    }
+  },
+
+  onCreate() {
+    this.storage.resolvedValues = this.options.resolvedValues
+    this.storage.showDynamicFieldValue = this.options.showDynamicFieldValue
+  },
+
+  addAttributes() {
+    return {
+      value: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('data-value'),
+        renderHTML: (attributes: Record<string, any>) => ({
+          'data-value': attributes.value,
+        }),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'autofill-field[data-value]' }]
+  },
 
   renderHTML({ HTMLAttributes }) {
-    return ['autofill', mergeAttributes(HTMLAttributes), 0]
+    return ['autofill-field', mergeAttributes(HTMLAttributes)]
   },
 
   addNodeView() {
     return ReactNodeViewRenderer(AutofillComponent)
+  },
+
+  addCommands() {
+    return {
+      insertAutofillField:
+        (attrs) =>
+        ({ chain }) =>
+          chain()
+            .focus()
+            .insertContent([
+              { type: this.name, attrs },
+              { type: 'text', text: ' ' },
+            ])
+            .run(),
+    }
+  },
+
+  addProseMirrorPlugins() {
+    const suggestion = autofillMenuSuggestion(
+      this.options.dynamicFields,
+      this.options.CustomDropdown,
+    )
+
+    return [
+      Suggestion<DynamicField>({
+        editor: this.editor,
+        pluginKey: autofillSuggestionKey,
+        char: suggestion.char,
+        items: suggestion.items,
+
+        command: ({ editor, range, props }) => {
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent([
+              { type: this.name, attrs: { value: props.value } },
+              { type: 'text', text: ' ' },
+            ])
+            .run()
+        },
+
+        render: suggestion.render,
+      }),
+    ]
   },
 })

--- a/lib/main.tsx
+++ b/lib/main.tsx
@@ -4,6 +4,15 @@ import { AppContextProvider } from './context'
 import './globals.css'
 import { TiptapEditorUtils } from './utils/tiptapEditorUtils'
 import { RefObject } from 'react'
+import type {
+  DynamicField,
+  DynamicFieldConfig,
+  DynamicFieldDropdownComponent,
+  DynamicFieldDropdownProps,
+  HandlebarTemplateComponent,
+  HandlebarTemplateProps,
+  ResolvedValues,
+} from './components/tiptap/autofieldSelector/autofill-field.types'
 
 export interface NotionLikeProps {
   uploadFn?: (file: File) => Promise<string | undefined>
@@ -48,6 +57,8 @@ export interface NotionLikeProps {
   parentContainerStyle?: React.CSSProperties
   endButtons?: React.ReactNode
   editorRef?: RefObject<HTMLDivElement>
+  /** Config for dynamic fields / handlebars. Passing this enables the feature. */
+  dynamicFieldConfig?: DynamicFieldConfig
 }
 
 export const Tapwrite = ({
@@ -73,6 +84,7 @@ export const Tapwrite = ({
   parentContainerStyle,
   endButtons,
   editorRef,
+  dynamicFieldConfig,
 }: NotionLikeProps) => {
   return (
     <AppContextProvider>
@@ -99,9 +111,19 @@ export const Tapwrite = ({
         parentContainerStyle={parentContainerStyle}
         endButtons={endButtons}
         editorRef={editorRef}
+        dynamicFieldConfig={dynamicFieldConfig}
       />
     </AppContextProvider>
   )
 }
 
 export { TiptapEditorUtils }
+export type {
+  DynamicField,
+  DynamicFieldConfig,
+  DynamicFieldDropdownProps,
+  DynamicFieldDropdownComponent,
+  HandlebarTemplateProps,
+  HandlebarTemplateComponent,
+  ResolvedValues,
+}

--- a/lib/utils/tiptapEditorUtils.ts
+++ b/lib/utils/tiptapEditorUtils.ts
@@ -148,11 +148,14 @@ export class TiptapEditorUtils {
       .run()
   }
 
-  insertAutofill(content: string) {
+  insertAutofill(value: string) {
     this.editor
       .chain()
       .focus()
-      .insertContent(`<autofill>${content}</autofill> `)
+      .insertContent([
+        { type: 'autofillField', attrs: { value } },
+        { type: 'text', text: ' ' },
+      ])
       .run()
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwrite",
   "private": false,
-  "version": "1.1.94",
+  "version": "1.1.95",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,19 +1,71 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import ReactDOM from 'react-dom/client'
 import { Tapwrite } from '../lib/main.tsx'
+import type { DynamicFieldConfig } from '../lib/main.tsx'
+
+const FIELDS = [
+  { value: '{{currentDate}}', label: 'Current Date' },
+  { value: '{{currentTime}}', label: 'Current Time' },
+  { value: '{{client.firstName}}', label: 'Client First Name' },
+  { value: '{{client.lastName}}', label: 'Client Last Name' },
+  { value: '{{client.email}}', label: 'Client Email' },
+  { value: '{{company.name}}', label: 'Company Name' },
+]
 
 const App = () => {
   const [content, setContent] = useState<string>(
-    '<p> ashdkasd </p> <img src = "https://picsum.photos/200/300" width ="75" height="112" /> <p> hello </p>'
+    '<p>Type {{ to insert a dynamic field. Try it here:</p><p></p>'
   )
+  const [showResolved, setShowResolved] = useState(false)
   const editRef = useRef<HTMLDivElement>(null)
-  return (
-    <div style={{ padding: '1.5em' }}>
-      <Tapwrite
-        uploadFn={async (file) => {
-          // const imgUtil = new ImagePickerUtils()
-          // const url = await imgUtil.imageUrl(file)
 
+  const [resolvedValues, setResolvedValues] = useState(() => ({
+    '{{currentDate}}': new Date().toLocaleDateString(),
+    '{{currentTime}}': new Date().toLocaleTimeString(),
+    '{{client.firstName}}': 'John',
+    '{{client.lastName}}': 'Doe',
+    '{{client.email}}': 'john@example.com',
+    '{{company.name}}': 'Acme Inc.',
+  }))
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setResolvedValues((prev) => ({
+        ...prev,
+        '{{currentDate}}': new Date().toLocaleDateString(),
+        '{{currentTime}}': new Date().toLocaleTimeString(),
+      }))
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const dynamicFieldConfig: DynamicFieldConfig = {
+    fields: FIELDS,
+    resolvedValues,
+    showResolved,
+  }
+
+  return (
+    <div style={{ padding: '1.5em', maxWidth: '700px', margin: '0 auto' }}>
+      <h2 style={{ marginBottom: '0.5em' }}>Tapwrite — Dynamic Fields Demo</h2>
+
+      <div style={{ marginBottom: '1em' }}>
+        <button
+          onClick={() => setShowResolved((v) => !v)}
+          style={{
+            padding: '6px 14px',
+            borderRadius: '4px',
+            border: '1px solid #ccc',
+            cursor: 'pointer',
+            background: showResolved ? '#e0f2e9' : '#fff',
+          }}
+        >
+          {showResolved ? 'Showing resolved values' : 'Showing template pills'}
+        </button>
+      </div>
+
+      <Tapwrite
+        uploadFn={async () => {
           const simulateDelay = () =>
             new Promise<string>((resolve) => {
               setTimeout(() => {
@@ -23,29 +75,15 @@ const App = () => {
           const url = await simulateDelay()
           return url || ''
         }}
-        handleImageClick={(event) => console.log(`\n\nClick`, event)}
-        handleImageDoubleClick={(event) =>
-          console.log(`\n\nDouble Click`, event)
-        }
         content={content}
         getContent={(newContent) => {
           setContent(newContent)
           console.log(newContent)
         }}
-        editorClass=''
+        editorClass=""
         editorRef={editRef}
-        hardbreak
+        dynamicFieldConfig={dynamicFieldConfig}
       />
-      <button
-        onClick={() => {
-          if (editRef.current) {
-            editRef.current.focus()
-          }
-        }}
-      >
-        {' '}
-        hi
-      </button>
     </div>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,71 +1,19 @@
-import React, { useRef, useState, useEffect } from 'react'
+import React, { useRef, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { Tapwrite } from '../lib/main.tsx'
-import type { DynamicFieldConfig } from '../lib/main.tsx'
-
-const FIELDS = [
-  { value: '{{currentDate}}', label: 'Current Date' },
-  { value: '{{currentTime}}', label: 'Current Time' },
-  { value: '{{client.firstName}}', label: 'Client First Name' },
-  { value: '{{client.lastName}}', label: 'Client Last Name' },
-  { value: '{{client.email}}', label: 'Client Email' },
-  { value: '{{company.name}}', label: 'Company Name' },
-]
 
 const App = () => {
   const [content, setContent] = useState<string>(
-    '<p>Type {{ to insert a dynamic field. Try it here:</p><p></p>'
+    '<p> ashdkasd </p> <img src = "https://picsum.photos/200/300" width ="75" height="112" /> <p> hello </p>'
   )
-  const [showResolved, setShowResolved] = useState(false)
   const editRef = useRef<HTMLDivElement>(null)
-
-  const [resolvedValues, setResolvedValues] = useState(() => ({
-    '{{currentDate}}': new Date().toLocaleDateString(),
-    '{{currentTime}}': new Date().toLocaleTimeString(),
-    '{{client.firstName}}': 'John',
-    '{{client.lastName}}': 'Doe',
-    '{{client.email}}': 'john@example.com',
-    '{{company.name}}': 'Acme Inc.',
-  }))
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setResolvedValues((prev) => ({
-        ...prev,
-        '{{currentDate}}': new Date().toLocaleDateString(),
-        '{{currentTime}}': new Date().toLocaleTimeString(),
-      }))
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [])
-
-  const dynamicFieldConfig: DynamicFieldConfig = {
-    fields: FIELDS,
-    resolvedValues,
-    showResolved,
-  }
-
   return (
-    <div style={{ padding: '1.5em', maxWidth: '700px', margin: '0 auto' }}>
-      <h2 style={{ marginBottom: '0.5em' }}>Tapwrite — Dynamic Fields Demo</h2>
-
-      <div style={{ marginBottom: '1em' }}>
-        <button
-          onClick={() => setShowResolved((v) => !v)}
-          style={{
-            padding: '6px 14px',
-            borderRadius: '4px',
-            border: '1px solid #ccc',
-            cursor: 'pointer',
-            background: showResolved ? '#e0f2e9' : '#fff',
-          }}
-        >
-          {showResolved ? 'Showing resolved values' : 'Showing template pills'}
-        </button>
-      </div>
-
+    <div style={{ padding: '1.5em' }}>
       <Tapwrite
-        uploadFn={async () => {
+        uploadFn={async (file) => {
+          // const imgUtil = new ImagePickerUtils()
+          // const url = await imgUtil.imageUrl(file)
+
           const simulateDelay = () =>
             new Promise<string>((resolve) => {
               setTimeout(() => {
@@ -75,15 +23,29 @@ const App = () => {
           const url = await simulateDelay()
           return url || ''
         }}
+        handleImageClick={(event) => console.log(`\n\nClick`, event)}
+        handleImageDoubleClick={(event) =>
+          console.log(`\n\nDouble Click`, event)
+        }
         content={content}
         getContent={(newContent) => {
           setContent(newContent)
           console.log(newContent)
         }}
-        editorClass=""
+        editorClass=''
         editorRef={editRef}
-        dynamicFieldConfig={dynamicFieldConfig}
+        hardbreak
       />
+      <button
+        onClick={() => {
+          if (editRef.current) {
+            editRef.current.focus()
+          }
+        }}
+      >
+        {' '}
+        hi
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds `dynamicFieldConfig` prop to `<Tapwrite />` that encapsulates all dynamic field/handlebar options (`fields`, `resolvedValues`, `showResolved`, `dropdownComponent`, `templateComponent`)
- Autofill extension auto-enables when `dynamicFieldConfig.fields` is provided — no explicit toggle needed
- Typing `{{` triggers a filterable suggestion dropdown with keyboard navigation
- Template pills render `{{value}}` in client-home-v3 style (rounded border, white bg, gray text)
- `showResolved` toggle switches all pills between handlebar templates and resolved values reactively
- Supports custom dropdown and template components for consumer-defined styling
- Exports `DynamicField`, `DynamicFieldConfig`, `HandlebarTemplateProps`, `HandlebarTemplateComponent`, `ResolvedValues` types

## Test plan
- [x] Pass `dynamicFieldConfig` with fields and verify `{{` triggers the dropdown
- [x] Select a field and verify the template pill renders with `{{value}}` format
- [x] Toggle `showResolved` and verify all pills switch to resolved values
- [x] Pass dynamically changing `resolvedValues` and verify the editor updates
- [x] Omit `dynamicFieldConfig` and verify autofill is completely disabled
- [x] Pass a custom `templateComponent` and verify it renders instead of the default pill
- [x] Pass a custom `dropdownComponent` and verify it renders instead of the default menu

## Testing Criteria 

- [LOOM](https://www.loom.com/share/702429c8aad94546a704bb2d720f35bc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)