### PR TITLE
OUT-3493 | Hyperlinks

### DIFF
--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -1,6 +1,6 @@
 import { EditorContent, useEditor } from '@tiptap/react'
 import * as React from 'react'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import Bold from '@tiptap/extension-bold'
 import BulletList from '@tiptap/extension-bullet-list'
@@ -10,7 +10,6 @@ import Document from '@tiptap/extension-document'
 import Heading from '@tiptap/extension-heading'
 import History from '@tiptap/extension-history'
 import Italic from '@tiptap/extension-italic'
-import Link from '@tiptap/extension-link'
 import ListItem from '@tiptap/extension-list-item'
 import OrderedList from '@tiptap/extension-ordered-list'
 import Paragraph from '@tiptap/extension-paragraph'
@@ -41,6 +40,10 @@ import FloatingCommandExtension from './tiptap/floatingMenu/floatingCommandExten
 import { floatingMenuSuggestion } from './tiptap/floatingMenu/floatingMenuSuggestion'
 import { IframeExtension } from './tiptap/iframe/ext_iframe'
 import { UploadImage } from './tiptap/image/imageUpload'
+import { LinkExt } from './tiptap/link/linkExt'
+import LinkBubbleInput from './tiptap/link/LinkBubbleInput'
+import LinkPreviewBubble from './tiptap/link/LinkPreviewBubble'
+import type { Editor as CoreEditor } from '@tiptap/core'
 // import suggestion from "../components/tiptap/mention/suggestion.ts";
 // import { MentionStorage } from "./tiptap/mention/MentionStorage.extension.ts";
 // mention turned off for now
@@ -82,6 +85,37 @@ export const Editor = ({
     'p-1.5 px-2.5  focus-within:border-black border-gray-300 bg-white border focus:border-black rounded-100  text-sm resize-y overflow-auto'
 
   const autofillEnabled = !!(dynamicFieldConfig?.fields?.length)
+
+  const [showLinkInput, setShowLinkInput] = useState(false)
+  const [linkHasTextSelection, setLinkHasTextSelection] = useState(false)
+  const [linkEditHref, setLinkEditHref] = useState<string | null>(null)
+  const [activeLinkHref, setActiveLinkHref] = useState<string | null>(null)
+
+  // Ref the floating-menu suggestion closure reads, so it always calls the latest setters
+  const linkStateSettersRef = useRef({
+    setShowLinkInput,
+    setLinkHasTextSelection,
+    setLinkEditHref,
+  })
+  linkStateSettersRef.current = {
+    setShowLinkInput,
+    setLinkHasTextSelection,
+    setLinkEditHref,
+  }
+
+  const triggerLinkInput = useCallback((editorInstance: CoreEditor) => {
+    const hasSelection = !editorInstance.state.selection.empty
+    linkStateSettersRef.current.setLinkHasTextSelection(hasSelection)
+    if (hasSelection && editorInstance.isActive('link')) {
+      const existingHref = editorInstance.getAttributes('link').href as
+        | string
+        | undefined
+      linkStateSettersRef.current.setLinkEditHref(existingHref ?? null)
+    } else {
+      linkStateSettersRef.current.setLinkEditHref(null)
+    }
+    linkStateSettersRef.current.setShowLinkInput(true)
+  }, [])
 
   const editor = useEditor({
     editorProps: {
@@ -178,7 +212,7 @@ export const Editor = ({
         },
       }),
       FloatingCommandExtension.configure({
-        suggestion: floatingMenuSuggestion(uploadFn),
+        suggestion: floatingMenuSuggestion(uploadFn, triggerLinkInput),
       }),
       Placeholder.configure({
         placeholder: ({ node }) => {
@@ -195,11 +229,7 @@ export const Editor = ({
           return initialEditorContent
         },
       }),
-      Link.extend({
-        exitable: true,
-      }).configure({
-        autolink: false,
-      }),
+      LinkExt,
       OrderedList.configure({
         itemTypeName: 'listItem',
         keepMarks: true,
@@ -332,6 +362,33 @@ export const Editor = ({
     editor.off('transaction', updateActiveStatus)
   }, [editor, onActiveStatusChange])
 
+  // Track whether the cursor is inside a link mark so we can show the preview bubble
+  useEffect(() => {
+    if (!editor) return
+    const updateActiveLinkHref = () => {
+      if (editor.isActive('link')) {
+        const href = editor.getAttributes('link').href as string | undefined
+        setActiveLinkHref(href ?? null)
+      } else {
+        setActiveLinkHref(null)
+      }
+    }
+    editor.on('selectionUpdate', updateActiveLinkHref)
+    editor.on('transaction', updateActiveLinkHref)
+    return () => {
+      editor.off('selectionUpdate', updateActiveLinkHref)
+      editor.off('transaction', updateActiveLinkHref)
+    }
+  }, [editor])
+
+  const showLinkPreview = !!activeLinkHref && !showLinkInput && !readonly
+
+  const handleChangeFromPreview = useCallback(() => {
+    setLinkEditHref(activeLinkHref)
+    setLinkHasTextSelection(true)
+    setShowLinkInput(true)
+  }, [activeLinkHref])
+
   if (!editor) return null
 
   return (
@@ -353,6 +410,7 @@ export const Editor = ({
             <ControlledBubbleMenu
               editor={editor}
               open={() => {
+                if (showLinkInput || showLinkPreview) return false
                 const { view, state } = editor
                 const { from, to } = view.state.selection
                 const text = state.doc.textBetween(from, to, '')
@@ -362,6 +420,37 @@ export const Editor = ({
               offset={[0, 10]}
             >
               <BubbleMenuContainer editor={editor} />
+            </ControlledBubbleMenu>
+            <ControlledBubbleMenu
+              editor={editor}
+              id='link-input-bubble-menu'
+              open={() => showLinkInput}
+              offset={[0, 8]}
+              placement='top-start'
+              fallbackPlacements={['bottom-start', 'top', 'bottom']}
+            >
+              <LinkBubbleInput
+                editor={editor}
+                showLinkInput={showLinkInput}
+                setShowLinkInput={setShowLinkInput}
+                hasTextSelection={linkHasTextSelection}
+                editHref={linkEditHref}
+                setEditHref={setLinkEditHref}
+              />
+            </ControlledBubbleMenu>
+            <ControlledBubbleMenu
+              editor={editor}
+              id='link-preview-bubble-menu'
+              open={() => showLinkPreview}
+              offset={[0, 8]}
+              placement='bottom-start'
+              fallbackPlacements={['top-start', 'bottom', 'top']}
+            >
+              <LinkPreviewBubble
+                editor={editor}
+                href={activeLinkHref ?? ''}
+                onChange={handleChangeFromPreview}
+              />
             </ControlledBubbleMenu>
           </div>
         )}

--- a/lib/components/tiptap/bubbleMenu/ControlledBubbleMenu.tsx
+++ b/lib/components/tiptap/bubbleMenu/ControlledBubbleMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Popper } from '@mui/material'
+import { Popper, PopperPlacementType } from '@mui/material'
 import { Editor, isNodeSelection, posToDOMRect } from '@tiptap/core'
 
 type Props = {
@@ -7,6 +7,9 @@ type Props = {
   open: () => boolean
   children: React.ReactNode
   offset: number[]
+  placement?: PopperPlacementType
+  fallbackPlacements?: PopperPlacementType[]
+  id?: string
 }
 
 const ControlledBubbleMenu: React.FC<Props> = ({
@@ -14,11 +17,20 @@ const ControlledBubbleMenu: React.FC<Props> = ({
   open,
   children,
   offset,
+  placement = 'top',
+  fallbackPlacements = [
+    'bottom',
+    'top-start',
+    'bottom-start',
+    'top-end',
+    'bottom-end',
+  ],
+  id = 'controlled-bubble-menu',
 }: Props) => (
   <Popper
-    id='controlled-bubble-menu'
+    id={id}
     open={open()}
-    placement='top'
+    placement={placement}
     modifiers={[
       {
         name: 'offset',
@@ -32,13 +44,7 @@ const ControlledBubbleMenu: React.FC<Props> = ({
         enabled: true,
         options: {
           boundary: editor.options.element,
-          fallbackPlacements: [
-            'bottom',
-            'top-start',
-            'bottom-start',
-            'top-end',
-            'bottom-end',
-          ],
+          fallbackPlacements,
           padding: 8,
         },
       },

--- a/lib/components/tiptap/floatingMenu/FloatingMenu.tsx
+++ b/lib/components/tiptap/floatingMenu/FloatingMenu.tsx
@@ -141,6 +141,10 @@ export const FloatingMenu = forwardRef((props: any, ref: any) => {
       }
 
       if (event.key === 'Enter') {
+        // Stop the native Enter from reaching window-level listeners
+        // in host apps (e.g. submit-on-Enter in a comment form) — the
+        // slash menu has handled the keypress, so nothing else should.
+        event.stopPropagation()
         enterHandler()
         return true
       }

--- a/lib/components/tiptap/floatingMenu/FloatingMenu.tsx
+++ b/lib/components/tiptap/floatingMenu/FloatingMenu.tsx
@@ -11,6 +11,7 @@ import {
   CalloutIcon,
   TableIcon,
   ImageUploadIcon,
+  LinkIconSDS,
 } from './../../../icons'
 
 import { useAppState } from '../../../context/useAppState'
@@ -58,6 +59,10 @@ const FloatingContainerBtn = ({
           <TableIcon />
         ) : label === 'Callout' ? (
           <CalloutIcon />
+        ) : label === 'Link' ? (
+          <span className='text-[#6B6F76] flex'>
+            <LinkIconSDS size={14} />
+          </span>
         ) : (
           <></>
         )}

--- a/lib/components/tiptap/floatingMenu/floatingMenuSuggestion.tsx
+++ b/lib/components/tiptap/floatingMenu/floatingMenuSuggestion.tsx
@@ -5,7 +5,8 @@ import { FloatingMenu } from './FloatingMenu'
 import { TiptapEditorUtils } from './../../../utils/tiptapEditorUtils'
 
 export const floatingMenuSuggestion = (
-  uploadFn?: (file: File) => Promise<string | undefined> | undefined
+  uploadFn?: (file: File) => Promise<string | undefined> | undefined,
+  onTriggerLink?: (editor: Editor) => void
 ) => ({
   items: ({ query }: any) => {
     const normalizedQuery = query.toLowerCase().replace(' ', '')
@@ -56,6 +57,14 @@ export const floatingMenuSuggestion = (
           const tiptapEditorUtils = new TiptapEditorUtils(editor)
           tiptapEditorUtils.deleteRange(range)
           tiptapEditorUtils.toggleNumberedList()
+        },
+      },
+      {
+        title: 'Link',
+        command: ({ editor, range }: { editor: Editor; range: any }) => {
+          const tiptapEditorUtils = new TiptapEditorUtils(editor)
+          tiptapEditorUtils.deleteRange(range)
+          onTriggerLink?.(editor)
         },
       },
       // {

--- a/lib/components/tiptap/link/LinkBubbleInput.tsx
+++ b/lib/components/tiptap/link/LinkBubbleInput.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react'
+import {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { Editor } from '@tiptap/core'
+import { LinkIconSDS, TextIconSDS } from './../../../icons'
+import { selectionHighlightKey } from './linkExt'
+
+const ensureHttps = (url: string): string => {
+  if (!url) return url
+  if (/^https?:\/\//i.test(url)) return url
+  if (/^mailto:/i.test(url)) return url
+  if (/^tel:/i.test(url)) return url
+  return `https://${url}`
+}
+
+interface LinkBubbleInputProps {
+  editor: Editor
+  showLinkInput: boolean
+  setShowLinkInput: (show: boolean) => void
+  hasTextSelection: boolean
+  editHref: string | null
+  setEditHref: (href: string | null) => void
+}
+
+export const LinkBubbleInput = ({
+  editor,
+  showLinkInput,
+  setShowLinkInput,
+  hasTextSelection,
+  editHref,
+  setEditHref,
+}: LinkBubbleInputProps) => {
+  const [displayText, setDisplayText] = useState('')
+  const [url, setUrl] = useState('')
+  const textInputRef = useRef<HTMLInputElement>(null)
+  const urlInputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleClose = useCallback(() => {
+    editor.view.dispatch(
+      editor.state.tr.setMeta(selectionHighlightKey, null)
+    )
+    setDisplayText('')
+    setUrl('')
+    setEditHref(null)
+    setShowLinkInput(false)
+  }, [editor, setShowLinkInput, setEditHref])
+
+  // Pre-fill URL when editing an existing link
+  useEffect(() => {
+    if (showLinkInput && editHref) {
+      setUrl(editHref)
+    }
+  }, [showLinkInput, editHref])
+
+  const handleSubmit = () => {
+    if (!url.trim()) return
+
+    const href = ensureHttps(url.trim())
+
+    if (hasTextSelection) {
+      editor.chain().focus().setLink({ href }).run()
+    } else {
+      const text = displayText.trim() || href
+      editor
+        .chain()
+        .focus()
+        .insertContent({
+          type: 'text',
+          marks: [{ type: 'link', attrs: { href } }],
+          text,
+        })
+        .run()
+    }
+
+    handleClose()
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      handleClose()
+      return
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  useEffect(() => {
+    if (!showLinkInput) return
+
+    const timer = setTimeout(() => {
+      if (hasTextSelection) {
+        const { from, to } = editor.state.selection
+        if (from !== to) {
+          editor.view.dispatch(
+            editor.state.tr.setMeta(selectionHighlightKey, { from, to })
+          )
+        }
+        urlInputRef.current?.focus()
+      } else {
+        textInputRef.current?.focus()
+      }
+    }, 50)
+
+    return () => clearTimeout(timer)
+  }, [showLinkInput, hasTextSelection, editor])
+
+  // Close when user clicks outside the popup (including into the editor)
+  useEffect(() => {
+    if (!showLinkInput) return
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if (containerRef.current?.contains(e.target as Node)) return
+      handleClose()
+    }
+
+    // Delay listener so the opening click doesn't immediately close it
+    const timer = setTimeout(() => {
+      document.addEventListener('pointerdown', handlePointerDown)
+    }, 0)
+
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [showLinkInput, handleClose])
+
+  return (
+    <div
+      ref={containerRef}
+      className='flex items-center gap-2 rounded-lg border border-[#DFE1E4] bg-white p-2 shadow-md'
+    >
+      <div className='flex flex-col gap-2'>
+        {!hasTextSelection && (
+          <div className='flex items-center gap-1 rounded border border-[#DFE1E4] px-2 py-1'>
+            <span className='shrink-0 text-[#6B6F76]'>
+              <TextIconSDS />
+            </span>
+            <input
+              ref={textInputRef}
+              type='text'
+              placeholder='Text to display'
+              value={displayText}
+              onChange={(e) => setDisplayText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className='w-52 text-xs leading-5 font-normal bg-transparent focus:outline-none'
+            />
+          </div>
+        )}
+        <div className='flex items-center gap-1 rounded border border-[#DFE1E4] px-2 py-1'>
+          <span className='shrink-0 text-[#6B6F76]'>
+            <LinkIconSDS />
+          </span>
+          <input
+            ref={urlInputRef}
+            type='text'
+            placeholder='Type or paste a link'
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className='w-52 text-xs leading-5 font-normal bg-transparent focus:outline-none'
+          />
+        </div>
+      </div>
+      <button
+        type='button'
+        onClick={handleSubmit}
+        disabled={!url.trim()}
+        className='shrink-0 rounded px-3 py-1 font-medium text-sm text-[#212B36] hover:bg-[#F8F9FB] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent'
+      >
+        {editHref ? 'Save' : 'Add'}
+      </button>
+    </div>
+  )
+}
+
+export default LinkBubbleInput

--- a/lib/components/tiptap/link/LinkBubbleInput.tsx
+++ b/lib/components/tiptap/link/LinkBubbleInput.tsx
@@ -84,12 +84,17 @@ export const LinkBubbleInput = ({
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Escape') {
       event.preventDefault()
+      event.stopPropagation()
       handleClose()
       return
     }
 
     if (event.key === 'Enter') {
+      // Stop the native Enter from reaching window-level listeners
+      // in host apps (e.g. submit-on-Enter in a comment form) — the
+      // link input has handled the keypress.
       event.preventDefault()
+      event.stopPropagation()
       handleSubmit()
     }
   }

--- a/lib/components/tiptap/link/LinkPreviewBubble.tsx
+++ b/lib/components/tiptap/link/LinkPreviewBubble.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react'
+import { useEffect, useRef, useSyncExternalStore } from 'react'
+import { Editor } from '@tiptap/core'
+
+const subscribe = (cb: () => void) => {
+  window.addEventListener('resize', cb)
+  return () => window.removeEventListener('resize', cb)
+}
+const getSnapshot = () => window.innerWidth
+
+interface LinkPreviewBubbleProps {
+  editor: Editor
+  href: string
+  onChange: () => void
+}
+
+export const LinkPreviewBubble = ({
+  editor,
+  href,
+  onChange,
+}: LinkPreviewBubbleProps) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const windowWidth = useSyncExternalStore(subscribe, getSnapshot, () => 450)
+  const isSmallScreen = windowWidth < 450
+  const displayHref =
+    isSmallScreen && href.length > 15 ? href.slice(0, 15) : href
+
+  const handleChange = () => {
+    // Select the full link text so setLink applies to it
+    const { $from } = editor.state.selection
+    const linkMark = $from.marks().find((m) => m.type.name === 'link')
+    if (linkMark) {
+      let from = $from.pos
+      let to = $from.pos
+      // Walk backwards to find link start
+      editor.state.doc.nodesBetween($from.start(), $from.pos, (node, pos) => {
+        if (node.isText && linkMark.isInSet(node.marks)) {
+          from = pos
+        }
+      })
+      // Walk forwards to find link end
+      editor.state.doc.nodesBetween($from.pos, $from.end(), (node, pos) => {
+        if (node.isText && linkMark.isInSet(node.marks)) {
+          to = pos + node.nodeSize
+        }
+      })
+      editor.chain().focus().setTextSelection({ from, to }).run()
+    }
+
+    onChange()
+  }
+
+  const handleRemove = () => {
+    editor.chain().focus().unsetLink().run()
+  }
+
+  // Nudge the popup left if it overflows the viewport.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    const reposition = () => {
+      el.style.marginLeft = '0px'
+
+      const rect = el.getBoundingClientRect()
+      const overflow = rect.right - window.innerWidth + 8
+      if (overflow > 0) {
+        el.style.marginLeft = `-${overflow}px`
+      }
+    }
+
+    const timer = setTimeout(reposition, 10)
+    window.addEventListener('resize', reposition)
+
+    return () => {
+      clearTimeout(timer)
+      window.removeEventListener('resize', reposition)
+    }
+  }, [href])
+
+  return (
+    <div
+      ref={containerRef}
+      className='flex w-max items-center gap-3 rounded-md border border-[#DFE1E4] bg-white px-3 py-2 shadow-md'
+    >
+      <span className='flex items-center gap-2'>
+        {!isSmallScreen && (
+          <p className='m-0 whitespace-nowrap text-sm font-normal leading-normal text-[#212B36]'>
+            Go to link:
+          </p>
+        )}
+        <a
+          target='_blank'
+          rel='noopener noreferrer'
+          href={href}
+          className='max-w-48 cursor-pointer overflow-hidden whitespace-nowrap text-sm text-[#1164A3] hover:underline'
+        >
+          {displayHref}
+        </a>
+      </span>
+      <div className='h-4 w-px shrink-0 bg-gray-300' />
+      <button
+        type='button'
+        onClick={handleChange}
+        className='shrink-0 cursor-pointer rounded border border-solid border-transparent bg-transparent px-3 py-1 hover:bg-[#F8F9FB]'
+      >
+        <p className='m-0 text-sm font-medium leading-none text-[#212B36]'>
+          Change
+        </p>
+      </button>
+      <div className='h-4 w-px shrink-0 bg-gray-300' />
+      <button
+        type='button'
+        onClick={handleRemove}
+        className='shrink-0 cursor-pointer rounded border border-solid border-transparent bg-transparent px-3 py-1 hover:bg-[#F8F9FB]'
+      >
+        <p className='m-0 text-sm font-medium leading-none text-[#212B36]'>
+          Remove
+        </p>
+      </button>
+    </div>
+  )
+}
+
+export default LinkPreviewBubble

--- a/lib/components/tiptap/link/linkExt.ts
+++ b/lib/components/tiptap/link/linkExt.ts
@@ -1,0 +1,71 @@
+import Link from '@tiptap/extension-link'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Decoration, DecorationSet } from '@tiptap/pm/view'
+
+export const selectionHighlightKey = new PluginKey('selectionHighlight')
+
+export const LinkExt = Link.extend({
+  inclusive: false,
+  exitable: true,
+
+  addProseMirrorPlugins() {
+    const parentPlugins = this.parent?.() ?? []
+
+    // Prevent browser default navigation when clicking links in the editor.
+    const preventClickPlugin = new Plugin({
+      key: new PluginKey('linkClickPrevention'),
+      props: {
+        handleClick: (view, _pos, event) => {
+          const target = event.target as HTMLElement
+          const link = target.closest('a')
+          if (link && view.editable) {
+            event.preventDefault()
+            return true
+          }
+          return false
+        },
+      },
+    })
+
+    // Show a highlight decoration over the selection when the editor loses
+    // focus to the link input, so the user can still see which text will
+    // receive the link.
+    const selectionHighlightPlugin = new Plugin({
+      key: selectionHighlightKey,
+      state: {
+        init: () => DecorationSet.empty,
+        apply: (tr, decorationSet, _oldState, newState) => {
+          const meta = tr.getMeta(selectionHighlightKey) as
+            | { from: number; to: number }
+            | null
+            | undefined
+          if (meta === null) return DecorationSet.empty
+          if (meta) {
+            return DecorationSet.create(newState.doc, [
+              Decoration.inline(meta.from, meta.to, {
+                class: 'selection-highlight',
+              }),
+            ])
+          }
+          return decorationSet.map(tr.mapping, tr.doc)
+        },
+      },
+      props: {
+        decorations(state) {
+          return selectionHighlightKey.getState(state)
+        },
+      },
+    })
+
+    return [...parentPlugins, preventClickPlugin, selectionHighlightPlugin]
+  },
+}).configure({
+  openOnClick: false,
+  autolink: true,
+  linkOnPaste: true,
+  HTMLAttributes: {
+    class: 'tapwrite-link',
+    rel: 'noopener noreferrer',
+    target: '_blank',
+  },
+})

--- a/lib/globals.css
+++ b/lib/globals.css
@@ -107,8 +107,17 @@
 }
 
 .tiptap a {
-  text-decoration: underline;
-  color: blue;
+  color: #1164A3;
+  text-decoration: none;
+  font-weight: inherit;
+  cursor: pointer;
+}
+
+/* Synthetic highlight shown over the editor selection while the link input has focus */
+.selection-highlight {
+  background-color: Highlight;
+  color: HighlightText;
+  padding: 2.5px 0;
 }
 
 .tiptap ul,

--- a/lib/icons/index.tsx
+++ b/lib/icons/index.tsx
@@ -258,6 +258,48 @@ export const LinkIcon = () => {
   )
 }
 
+// Mirrors the Link icon from @assembly-js/design-system.
+export const LinkIconSDS = ({
+  size = 16,
+  color = 'currentColor',
+}: { size?: number; color?: string } = {}) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 20 20'
+      width={size}
+      height={size}
+    >
+      <path
+        fill={color}
+        d='M14.844 4.104c-.743 0-1.465.24-2.06.674a7 7 0 0 0-1.333-1.066 5.156 5.156 0 0 1 7.039 7.528l-2.747 2.746a5.157 5.157 0 0 1-8.476-5.448.836.836 0 0 1 1.566.58 3.49 3.49 0 0 0 5.733 3.69l2.746-2.745a3.49 3.49 0 0 0-2.469-5.958M7.899 6.05a3.5 3.5 0 0 0-2.465 1.02L2.688 9.816a3.49 3.49 0 0 0 2.468 5.955c.743 0 1.466-.24 2.06-.674.395.41.846.768 1.333 1.066A5.156 5.156 0 0 1 1.51 8.635L4.257 5.89a5.157 5.157 0 0 1 8.476 5.448.836.836 0 0 1-1.566-.58A3.49 3.49 0 0 0 7.9 6.049'
+      />
+    </svg>
+  )
+}
+
+// Mirrors the Text icon from @assembly-js/design-system.
+export const TextIconSDS = ({
+  size = 16,
+  color = 'currentColor',
+}: { size?: number; color?: string } = {}) => {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 20 20'
+      width={size}
+      height={size}
+    >
+      <path
+        fill={color}
+        d='M3.714 3.714V5.43a.855.855 0 0 1-.857.857A.855.855 0 0 1 2 5.429v-2C2 2.639 2.64 2 3.429 2H16.57C17.361 2 18 2.64 18 3.429v2a.855.855 0 0 1-.857.857.855.855 0 0 1-.857-.857V3.714h-5.429v12.572h1.714c.475 0 .858.382.858.857a.855.855 0 0 1-.858.857H7.43a.855.855 0 0 1-.858-.857c0-.475.383-.857.858-.857h1.714V3.714z'
+      />
+    </svg>
+  )
+}
+
 export const CalloutIcon = () => {
   return (
     <svg

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwrite",
   "private": false,
-  "version": "1.1.98",
+  "version": "1.1.99",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tapwrite",
   "private": false,
-  "version": "1.1.97",
+  "version": "1.1.98",
   "type": "module",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,10 @@ import { Tapwrite } from '../lib/main.tsx'
 
 const App = () => {
   const [content, setContent] = useState<string>(
-    '<p> ashdkasd </p> <img src = "https://picsum.photos/200/300" width ="75" height="112" /> <p> hello </p>'
+    '<p> ashdkasd </p> <img src = "https://picsum.photos/200/300" width ="75" height="112" /> <p> hello <a target="_blank" rel="noopener noreferrer" class="tapwrite-link" href="https://asdasdasd">asdasd</a> </p>'
   )
+
+  console.log(content)
   const editRef = useRef<HTMLDivElement>(null)
   return (
     <div style={{ padding: '1.5em' }}>
@@ -34,7 +36,7 @@ const App = () => {
         }}
         editorClass=''
         editorRef={editRef}
-        hardbreak
+readonly
       />
       <button
         onClick={() => {


### PR DESCRIPTION
## Summary
- Add a "Link" item to the slash command menu with a bubble input popup (two modes: "Text to display" + URL when no selection, URL-only when text is selected or editing an existing link)
- Show a link preview bubble (Go to link / Change / Remove) when the cursor is placed inside an existing link, matching the Messages App design
- Normalize URLs to prepend `https://` so users no longer need to type it explicitly
- Style links as `#1164A3` with no underline or bold per the ticket
- Auto-link on paste / on type via `autolink` + `linkOnPaste`, and set `inclusive: false` so typing after a link doesn't extend the mark
- Icons (`LinkIconSDS`, `TextIconSDS`) ported from `@assembly-js/design-system` as static SVGs

## Test plan
- [x] Type `/link` → slash menu shows "Link" with the design-system link icon → select → popup appears with Text + URL inputs
- [x] Enter text + URL → hyperlink inserted with that display text
- [x] Enter URL only (no https://) → auto-prepended `https://`
- [x] Paste a URL → auto-links
- [x] Click on an existing link → preview bubble with Go to link / Change / Remove
- [x] Click "Change" → bubble input opens with URL pre-filled and button labelled "Save"
- [x] Click "Remove" → link mark removed from the text
- [x] Press Escape / click outside the popup → closes
- [x] Type after a link → new text is NOT part of the link (inclusive: false)
- [x] Links render in `#1164A3`, no underline, no bold

## Test

- [LOOM](https://www.loom.com/share/028c36faca654561a90de3d87fefb514)

Also verified, readonly directly opens the link on click without opening the link change/remove options

Linear: https://linear.app/assemblycom/issue/OUT-3493/hyperlinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)